### PR TITLE
Read flag values also from envrionment variables.

### DIFF
--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -23,6 +23,12 @@ func main() {
 	flag.StringVar(&prefix, "prefix", "", "prefix for environment variables")
 	flag.IntVar(&retries, "retries", 0, "number of times of retry")
 	flag.BoolVar(&versionFlag, "version", false, "display version")
+	flag.VisitAll(func(f *flag.Flag) {
+		// read flag values also from environment variable e.g. SSMWRAP_PATHS
+		if s := os.Getenv("SSMWRAP_" + strings.ToUpper(f.Name)); s != "" {
+			f.Value.Set(s)
+		}
+	})
 	flag.Parse()
 
 	if versionFlag {


### PR DESCRIPTION
This is useful for running as container entrypoint.

I hope to set flags for each environments when running a container.
But CMD and ENTRYPOINT does not evaluate command line arguments as environment variable.

```Dockerfile
SSMWRAP_PATHS=/development        # default.
CMD ["ssmwrap", "some-command"]
```

This not works.
```Dockerfile
CMD ["ssmwrap", "-paths", "${SSMWRAP_PATHS}", "some-command"]
```
