### PR TITLE
Doesn't apply string.ToUpper to environment name.

### DIFF
--- a/env.go
+++ b/env.go
@@ -24,7 +24,7 @@ func formatParametersAsEnvVars(parameters map[string]string, prefix string) []st
 
 	for name, value := range parameters {
 		parts := strings.Split(name, "/")
-		key := strings.ToUpper(prefix + parts[len(parts)-1])
+		key := prefix + parts[len(parts)-1]
 		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -13,18 +13,18 @@ func TestFormatParametersAsEnvVars(t *testing.T) {
 		Expected        []string
 	}{
 		{
-			Title: "to upper",
+			Title: "preserve lower case",
 			InputParameters: map[string]string{
 				"/foo": "bar",
 			},
 			Expected: []string{
-				"FOO=bar",
+				"foo=bar",
 			},
 		},
 		{
 			Title: "deep path",
 			InputParameters: map[string]string{
-				"/d/e/e/p/path": "deep",
+				"/d/e/e/p/PATH": "deep",
 			},
 			Expected: []string{
 				"PATH=deep",
@@ -37,17 +37,7 @@ func TestFormatParametersAsEnvVars(t *testing.T) {
 			},
 			InputPrefix: "MY_",
 			Expected: []string{
-				"MY_NAME=john",
-			},
-		},
-		{
-			Title: "prefix will be upper, too",
-			InputParameters: map[string]string{
-				"/common/title": "event",
-			},
-			InputPrefix: "my_",
-			Expected: []string{
-				"MY_TITLE=event",
+				"MY_name=john",
 			},
 		},
 	}


### PR DESCRIPTION
Hi,

I try to use this command with Terraform.
[Terraform needs case-sensitive environment names.](https://www.terraform.io/docs/configuration/variables.html#environment-variables)

> For example, given the configuration below:
>
> `variable "image" {}`
>
> The variable can be set via an environment variable:
> 
> `$ TF_VAR_image=foo terraform apply`

I think this command shouldn't apply ToUpper to environment name,
because environment name is case-sensitive in Linux systems.

Thanks,