### PR TITLE
Add Export() function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ but I couldn't find that manipulate values including newline characters correctl
 ssmwrap runs your command through syscall.Exec, not via shell,
 so newline characters are treated as part of a environment value.
 
+## Usage as a library
+
+`ssmwrap.Export()` fetches parameters from SSM and export those to envrionment variables.
+
+```go
+err := ssmwrap.Export(ssmwrap.Options{
+	Paths: []string{"/path/"},
+	Retries: 3,
+	EnvPrefix: "SSM_",
+})
+if err != nil {
+	// ...
+}
+foo := os.Getenv("SSM_FOO")  // a value of /path/foo in SSM
+```
+
 ## Licence
 
 MIT

--- a/env.go
+++ b/env.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // prepareEnvironmentVariables transform SSM parameters to environment variables like `FOO=bar`
@@ -29,4 +31,17 @@ func formatParametersAsEnvVars(parameters map[string]string, prefix string) []st
 	}
 
 	return envVars
+}
+
+func export(envVars []string) error {
+	for _, v := range envVars {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) != 2 {
+			return errors.New("= is not contained in envvars")
+		}
+		if err := os.Setenv(parts[0], parts[1]); err != nil {
+			return errors.Wrap(err, "setenv failed")
+		}
+	}
+	return nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -1,6 +1,7 @@
 package ssmwrap
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
@@ -59,6 +60,37 @@ func TestFormatParametersAsEnvVars(t *testing.T) {
 
 		if !reflect.DeepEqual(envVars, pattern.Expected) {
 			t.Errorf("unexpected envVars: %+v", envVars)
+		}
+	}
+}
+
+func TestExport(t *testing.T) {
+	patterns := []struct {
+		Title    string
+		EnvVars  []string
+		Expected map[string]string
+	}{
+		{
+			Title:   "simple",
+			EnvVars: []string{"FOO=foo", "BAR=bar=baz"},
+			Expected: map[string]string{
+				"FOO": "foo",
+				"BAR": "bar=baz",
+			},
+		},
+	}
+
+	for _, pattern := range patterns {
+		t.Log(pattern.Title)
+
+		err := export(pattern.EnvVars)
+		if err != nil {
+			t.Error(err)
+		}
+		for key, value := range pattern.Expected {
+			if env := os.Getenv(key); env != value {
+				t.Errorf("unexpected env %s=%s (expected %s)", key, env, value)
+			}
 		}
 	}
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -46,7 +46,7 @@ func Run(options Options) error {
 	return nil
 }
 
-// Export fetches paramters from SSM and export to environment variables.
+// Export fetches paramters from SSM and export those to environment variables.
 // This is for use ssmwrap as a library.
 func Export(options Options) error {
 	parameters, err := fetchParameters(options.Paths, options.Retries)

--- a/wrapper.go
+++ b/wrapper.go
@@ -46,6 +46,18 @@ func Run(options Options) error {
 	return nil
 }
 
+// Export fetches paramters from SSM and export to environment variables.
+// This is for use ssmwrap as a library.
+func Export(options Options) error {
+	parameters, err := fetchParameters(options.Paths, options.Retries)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch parameters from SSM")
+	}
+
+	envVars := formatParametersAsEnvVars(parameters, options.EnvPrefix)
+	return export(envVars)
+}
+
 func fetchParameters(paths []string, retries int) (map[string]string, error) {
 	params := map[string]string{}
 


### PR DESCRIPTION
This is for use ssmwrap as a library.

for example,
```go
	ssmwrap.Export(ssmwrap.Options{
		Paths: []string{"/path/"},
		Retries: 3,
		EnvPrefix: "SSM_",
	})
	foo := os.Getenv("SSM_FOO")  // a value of /path/foo in SSM
```