### PR TITLE
return exit 1 when error occurred

### DIFF
--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -210,5 +210,6 @@ func main() {
 
 	if err := ssmwrap.Run(options, ssm, dests); err != nil {
 		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
I want to know ssmwrap command failed, so exit code to be 1 when ssmwrap.Run() return error.