### PR TITLE
Add -names option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ Usage of ./cmd/ssmwrap/ssmwrap:
     	write values as file
     	format:  Name=VALUE_NAME,Path=FILE_PATH,Mode=FILE_MODE,Gid=FILE_GROUP_ID,Uid=FILE_USER_ID
     	example: Name=/foo/bar,Path=/etc/bar,Mode=600,Gid=123,Uid=456
+  -names string
+        comma separated parameter names
   -no-env
     	disable export to environment variables
   -no-recursive
     	retrieve values just under -paths only
   -paths string
-    	comma separated parameter paths (default "/")
+        comma separated parameter paths
   -prefix string
     	alias for -env-prefix
   -recursive

--- a/app.go
+++ b/app.go
@@ -10,10 +10,7 @@ import (
 )
 
 type SSMConnector interface {
-	FetchParameters(paths []string, recursive bool, retries int) (map[string]string, error)
-	FetchParametersByNames(names []string, retries int) (map[string]string, error)
-
-	fetchParameters(client *ssm.SSM, paths []string, recursive bool) (map[string]string, error)
+	fetchParametersByPaths(client *ssm.SSM, paths []string, recursive bool) (map[string]string, error)
 	fetchParametersByNames(client *ssm.SSM, names []string) (map[string]string, error)
 }
 
@@ -48,7 +45,7 @@ func Run(options RunOptions, ssm SSMConnector, dests []Destination) error {
 	parameters := map[string]string{}
 
 	{
-		p, err := ssm.fetchParameters(client, options.Paths, options.Recursive)
+		p, err := ssm.fetchParametersByPaths(client, options.Paths, options.Recursive)
 		if err != nil {
 			return errors.Wrap(err, "failed to fetch parameters from SSM")
 		}

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -140,6 +140,7 @@ func flagViaEnv(prefix string, multiple bool) []string {
 func main() {
 	var (
 		paths           string
+		names           string
 		recursiveFlag   bool
 		noRecursiveFlag bool
 		retries         int
@@ -153,7 +154,8 @@ func main() {
 		versionFlag bool
 	)
 
-	flag.StringVar(&paths, "paths", "/", "comma separated parameter paths")
+	flag.StringVar(&paths, "paths", "", "comma separated parameter paths")
+	flag.StringVar(&names, "names", "", "comma separated parameter names")
 	flag.BoolVar(&recursiveFlag, "recursive", true, "retrieve values recursively")
 	flag.BoolVar(&noRecursiveFlag, "no-recursive", false, "retrieve values just under -paths only")
 	flag.IntVar(&retries, "retries", 0, "number of times of retry")
@@ -187,10 +189,16 @@ func main() {
 	}
 
 	options := ssmwrap.RunOptions{
-		Paths:     strings.Split(paths, ","),
 		Recursive: !noRecursiveFlag,
 		Retries:   retries,
 		Command:   flag.Args(),
+	}
+
+	if paths != "" {
+		options.Paths = strings.Split(paths, ",")
+	}
+	if names != "" {
+		options.Names = strings.Split(names, ",")
 	}
 
 	ssm := ssmwrap.DefaultSSMConnector{}

--- a/lib.go
+++ b/lib.go
@@ -27,7 +27,7 @@ func Export(options ExportOptions) error {
 	}
 
 	{
-		p, err := ssm.fetchParameters(client, options.Paths, options.Recursive)
+		p, err := ssm.fetchParametersByPaths(client, options.Paths, options.Recursive)
 		if err != nil {
 			return errors.Wrap(err, "failed to fetch parameters from SSM")
 		}

--- a/lib.go
+++ b/lib.go
@@ -6,6 +6,7 @@ import (
 
 type ExportOptions struct {
 	Paths     []string
+	Names     []string
 	Prefix    string
 	Recursive bool
 	Retries   int
@@ -19,9 +20,30 @@ func Export(options ExportOptions) error {
 		Prefix: options.Prefix,
 	}
 
-	parameters, err := ssm.FetchParameters(options.Paths, options.Recursive, options.Retries)
+	parameters := map[string]string{}
+	client, err := newSSMClient(options.Retries)
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch parameters from SSM")
+		return err
+	}
+
+	{
+		p, err := ssm.fetchParameters(client, options.Paths, options.Recursive)
+		if err != nil {
+			return errors.Wrap(err, "failed to fetch parameters from SSM")
+		}
+		for key, value := range p {
+			parameters[key] = value
+		}
+	}
+
+	{
+		p, err := ssm.fetchParametersByNames(client, options.Names)
+		if err != nil {
+			return errors.Wrap(err, "failed to fetch parameters from SSM")
+		}
+		for key, value := range p {
+			parameters[key] = value
+		}
 	}
 
 	envVars := dest.formatParametersAsEnvVars(parameters)

--- a/ssm.go
+++ b/ssm.go
@@ -57,7 +57,7 @@ func (c DefaultSSMConnector) fetchParameters(client *ssm.SSM, paths []string, re
 	return params, nil
 }
 
-func (c DefaultSSMConnector) FetchParametersByNames(paths []string, retries int) (map[string]string, error) {
+func (c DefaultSSMConnector) FetchParametersByNames(names []string, retries int) (map[string]string, error) {
 	client, err := newSSMClient(retries)
 	if err != nil {
 		return nil, err

--- a/ssm.go
+++ b/ssm.go
@@ -9,15 +9,7 @@ import (
 
 type DefaultSSMConnector struct{}
 
-func (c DefaultSSMConnector) FetchParameters(paths []string, recursive bool, retries int) (map[string]string, error) {
-	client, err := newSSMClient(retries)
-	if err != nil {
-		return nil, err
-	}
-	return c.fetchParameters(client, paths, recursive)
-}
-
-func (c DefaultSSMConnector) fetchParameters(client *ssm.SSM, paths []string, recursive bool) (map[string]string, error) {
+func (c DefaultSSMConnector) fetchParametersByPaths(client *ssm.SSM, paths []string, recursive bool) (map[string]string, error) {
 	params := map[string]string{}
 	if len(paths) == 0 {
 		return params, nil
@@ -55,14 +47,6 @@ func (c DefaultSSMConnector) fetchParameters(client *ssm.SSM, paths []string, re
 	}
 
 	return params, nil
-}
-
-func (c DefaultSSMConnector) FetchParametersByNames(names []string, retries int) (map[string]string, error) {
-	client, err := newSSMClient(retries)
-	if err != nil {
-		return nil, err
-	}
-	return c.fetchParametersByNames(client, paths)
 }
 
 func (c DefaultSSMConnector) fetchParametersByNames(client *ssm.SSM, names []string) (map[string]string, error) {


### PR DESCRIPTION
Enable to specify parameter names directly instead of using paths.

This PR has a breaking compatibility changes.
`-paths` option becomes to have not a default value ("/"), because we sometimes want to use the `-name` option only.

