### PR TITLE
Fetch parameters in -file options.

### DIFF
--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -214,6 +214,9 @@ func main() {
 		dests = append(dests, ssmwrap.DestinationFile{
 			Targets: fileTargets,
 		})
+		for _, t := range fileTargets {
+			options.Names = append(options.Names, t.Name)
+		}
 	}
 
 	if err := ssmwrap.Run(options, ssm, dests); err != nil {

--- a/ssm.go
+++ b/ssm.go
@@ -51,7 +51,7 @@ func (c DefaultSSMConnector) fetchParametersByPaths(client *ssm.SSM, paths []str
 }
 
 func (c DefaultSSMConnector) fetchParametersByNames(client *ssm.SSM, names []string) (map[string]string, error) {
-	params := map[string]string{}
+	params := make(map[string]string, len(names))
 	if len(names) == 0 {
 		return params, nil
 	}
@@ -60,6 +60,10 @@ func (c DefaultSSMConnector) fetchParametersByNames(client *ssm.SSM, names []str
 		WithDecryption: aws.Bool(true),
 	}
 	for _, name := range names {
+		if _, exists := params[name]; exists { // discard duplication
+			continue
+		}
+		params[name] = ""
 		input.Names = append(input.Names, aws.String(name))
 	}
 


### PR DESCRIPTION
I had an unexpected result with -file options without -names or -paths options.

```
$ ssmwrap -file Name=/foo,Path=/tmp/foo -- ls -l /tmp/foo
----------  1 fujiwara  staff  0 12 26 09:49 /tmp/foo
```

I expect to get a value of /foo into /tmp/foo, but an empty file created.

This PR adds the name of -file options into -names to fetch those parameters from SSM.

refs #21