### PR TITLE
Enable shared config state

### DIFF
--- a/ssm.go
+++ b/ssm.go
@@ -80,7 +80,9 @@ func (c DefaultSSMConnector) fetchParametersByNames(client *ssm.SSM, names []str
 }
 
 func newSSMClient(retries int) (*ssm.SSM, error) {
-	sess, err := session.NewSession()
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to start session: %w", err)
 	}


### PR DESCRIPTION
When using ssmwrap, we needed to specify `AWS_REGION=...` even if region is specified in `.aws/config`.
By enabling reading shared config, environment variable will not be required.
I think, there are no risk to read shared config.