### PR TITLE
no need to initialize by empty string.

### DIFF
--- a/ssm.go
+++ b/ssm.go
@@ -63,7 +63,6 @@ func (c DefaultSSMConnector) fetchParametersByNames(client *ssm.SSM, names []str
 		if _, exists := params[name]; exists { // discard duplication
 			continue
 		}
-		params[name] = ""
 		input.Names = append(input.Names, aws.String(name))
 	}
 


### PR DESCRIPTION
When `-names FOO:1` like versioned name specified, ssmwrap exported `FOO:1` to environment variables.
No need to export the versioned name variable.

At current version,

```console
$ ssmwrap -names /path/to/FOO:1 -- env | grep FOO
FOO:1=
FOO=foo
```

This PR changes the behavior to,

```console
$ ssmwrap -names /path/to/FOO:1 -- env | grep FOO
FOO=foo
```
