### PR TITLE
command as 1st args is required.

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,6 +1,7 @@
 package ssmwrap
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -79,6 +80,9 @@ func Run(options RunOptions, ssm SSMConnector, dests []Destination) error {
 }
 
 func runCommand(command, envVars []string) error {
+	if len(command) == 0 {
+		return errors.New("command required")
+	}
 	bin, err := exec.LookPath(command[0])
 	if err != nil {
 		return err

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -193,6 +193,10 @@ func main() {
 		Retries:   retries,
 		Command:   flag.Args(),
 	}
+	if len(options.Command) == 0 {
+		fmt.Fprintln(os.Stderr, "command required in arguments")
+		os.Exit(2)
+	}
 
 	if paths != "" {
 		options.Paths = strings.Split(paths, ",")


### PR DESCRIPTION
Avoid dying with an index out of range.

Currently, 

```console
$ ssmwrap
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/handlename/ssmwrap.runCommand(0xc00009c000, 0x0, 0x0, 0xc000012500, 0x27, 0x27, 0x0, 0x0)
	/Users/fujiwara/src/github.com/handlename/ssmwrap/app.go:82 +0xf7
github.com/handlename/ssmwrap.Run(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0xc00009c000, 0x0, ...)
	/Users/fujiwara/src/github.com/handlename/ssmwrap/app.go:74 +0x3ee
main.main()
	/Users/fujiwara/src/github.com/handlename/ssmwrap/cmd/ssmwrap/main.go:222 +0x8dc

$ echo $?
2
```

This PR becomes to,

```console
$ ssmwrap
command required in arguments

$ echo $?
2
```