### PR TITLE
fix: use entire parameter path as environment variable name

### DIFF
--- a/dest_env.go
+++ b/dest_env.go
@@ -38,7 +38,7 @@ func (d DestinationEnv) formatParametersAsEnvVars(parameters map[string]string) 
 
 	for name, value := range parameters {
 		parts := strings.Split(name, "/")
-		key := strings.ToUpper(d.Prefix + parts[len(parts)-1])
+		key := strings.ToUpper(d.Prefix + strings.Join(parts[1:], "_"))
 		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
 	}
 

--- a/dest_env_test.go
+++ b/dest_env_test.go
@@ -28,7 +28,7 @@ func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 				"/d/e/e/p/path": "deep",
 			},
 			Expected: []string{
-				"PATH=deep",
+				"D_E_E_P_PATH=deep",
 			},
 		},
 		{
@@ -38,7 +38,7 @@ func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 			},
 			InputPrefix: "MY_",
 			Expected: []string{
-				"MY_NAME=john",
+				"MY_COMMON_NAME=john",
 			},
 		},
 		{
@@ -48,7 +48,7 @@ func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 			},
 			InputPrefix: "my_",
 			Expected: []string{
-				"MY_TITLE=event",
+				"MY_COMMON_TITLE=event",
 			},
 		},
 	}
@@ -63,7 +63,7 @@ func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 		envVars := dest.formatParametersAsEnvVars(pattern.InputParameters)
 
 		if !reflect.DeepEqual(envVars, pattern.Expected) {
-			t.Errorf("unexpected envVars: %+v", envVars)
+			t.Errorf("unexpected envVars\n\tgot:%+v\n\texpected:%+v", envVars, pattern.Expected)
 		}
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE: Parameters' uniqueness guaranteed by its entire path not only the last part of the path.

fix #50