### PR TITLE
add flag -env-entire-path

### DIFF
--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -145,9 +145,10 @@ func main() {
 		noRecursiveFlag bool
 		retries         int
 
-		envOutputFlag   bool
-		envNoOutputFlag bool
-		envPrefix       string
+		envOutputFlag    bool
+		envNoOutputFlag  bool
+		envPrefix        string
+		envUseEntirePath bool
 
 		fileTargets FileTargets
 
@@ -163,6 +164,7 @@ func main() {
 	flag.BoolVar(&envOutputFlag, "env", true, "export values as environment variables")
 	flag.BoolVar(&envNoOutputFlag, "no-env", false, "disable export to environment variables")
 	flag.StringVar(&envPrefix, "env-prefix", "", "prefix for environment variables")
+	flag.BoolVar(&envUseEntirePath, "env-entire-path", false, "use entire parameter path for name of environment variables\ndisabled: /path/to/value -> VALUE\nenabled: /path/to/value -> PATH_TO_VALUE")
 	flag.StringVar(&envPrefix, "prefix", "", "alias for -env-prefix")
 
 	flag.Var(&fileTargets, "file", "write values as file\nformat:  Name=VALUE_NAME,Path=FILE_PATH,Mode=FILE_MODE,Gid=FILE_GROUP_ID,Uid=FILE_USER_ID\nexample: Name=/foo/bar,Path=/etc/bar,Mode=600,Gid=123,Uid=456")
@@ -210,7 +212,8 @@ func main() {
 
 	if !envNoOutputFlag {
 		dests = append(dests, ssmwrap.DestinationEnv{
-			Prefix: envPrefix,
+			Prefix:        envPrefix,
+			UseEntirePath: envUseEntirePath,
 		})
 	}
 

--- a/dest_env.go
+++ b/dest_env.go
@@ -8,7 +8,8 @@ import (
 
 // DestinationEnv is an implementation of Destination interface.
 type DestinationEnv struct {
-	Prefix string
+	Prefix        string
+	UseEntirePath bool
 }
 
 func (d DestinationEnv) Name() string {
@@ -38,7 +39,14 @@ func (d DestinationEnv) formatParametersAsEnvVars(parameters map[string]string) 
 
 	for name, value := range parameters {
 		parts := strings.Split(name, "/")
-		key := strings.ToUpper(d.Prefix + strings.Join(parts[1:], "_"))
+
+		var key string
+		if d.UseEntirePath {
+			key = strings.ToUpper(d.Prefix + strings.Join(parts[1:], "_"))
+		} else {
+			key = strings.ToUpper(d.Prefix + parts[len(parts)-1])
+		}
+
 		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
 	}
 

--- a/dest_env_test.go
+++ b/dest_env_test.go
@@ -8,10 +8,11 @@ import (
 
 func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 	patterns := []struct {
-		Title           string
-		InputParameters map[string]string
-		InputPrefix     string
-		Expected        []string
+		Title              string
+		InputParameters    map[string]string
+		InputPrefix        string
+		InputUseEntirePath bool
+		Expected           []string
 	}{
 		{
 			Title: "to upper",
@@ -28,6 +29,16 @@ func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 				"/d/e/e/p/path": "deep",
 			},
 			Expected: []string{
+				"PATH=deep",
+			},
+		},
+		{
+			Title: "deep path, enable entire path",
+			InputParameters: map[string]string{
+				"/d/e/e/p/path": "deep",
+			},
+			InputUseEntirePath: true,
+			Expected: []string{
 				"D_E_E_P_PATH=deep",
 			},
 		},
@@ -38,7 +49,7 @@ func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 			},
 			InputPrefix: "MY_",
 			Expected: []string{
-				"MY_COMMON_NAME=john",
+				"MY_NAME=john",
 			},
 		},
 		{
@@ -48,7 +59,7 @@ func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 			},
 			InputPrefix: "my_",
 			Expected: []string{
-				"MY_COMMON_TITLE=event",
+				"MY_TITLE=event",
 			},
 		},
 	}
@@ -57,7 +68,8 @@ func TestDestinationEnvFormatParametersAsEnvVars(t *testing.T) {
 		t.Log(pattern.Title)
 
 		dest := DestinationEnv{
-			Prefix: pattern.InputPrefix,
+			Prefix:        pattern.InputPrefix,
+			UseEntirePath: pattern.InputUseEntirePath,
 		}
 
 		envVars := dest.formatParametersAsEnvVars(pattern.InputParameters)


### PR DESCRIPTION
enable to using entire path of parameter.
rel #51

```console
$ aws ssm get-parameters-by-path --path /test --recursive | jq '.Parameters[].Name'
"/test/parameter/foo"

$ ssmwrap -paths /test -- env | ag FOO
FOO=this is foo

$ ssmwrap -paths /test -env-entire-path -- env | ag FOO
TEST_PARAMETER_FOO=this is foo
```