### PR TITLE
io/ioutil is deprecated

### DIFF
--- a/dest_file.go
+++ b/dest_file.go
@@ -2,7 +2,6 @@ package ssmwrap
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -19,7 +18,7 @@ func (d DestinationFile) Name() string {
 
 func (d DestinationFile) Output(parameters map[string]string) error {
 	for _, target := range d.Targets {
-		err := ioutil.WriteFile(target.Path, []byte(parameters[target.Name]), target.Mode)
+		err := os.WriteFile(target.Path, []byte(parameters[target.Name]), target.Mode)
 		if err != nil {
 			return fmt.Errorf("failed to write to file %s: %w", target.Path, err)
 		}

--- a/dest_file_test.go
+++ b/dest_file_test.go
@@ -1,7 +1,7 @@
 package ssmwrap
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +47,7 @@ func TestDestinationFileOutputSuccessAll(t *testing.T) {
 			t.Errorf("failed to open target file: %s", err)
 		}
 
-		body, err := ioutil.ReadAll(f)
+		body, err := io.ReadAll(f)
 		if err != nil {
 			t.Errorf("failed to read body from file: %s", err)
 		}
@@ -59,7 +59,7 @@ func TestDestinationFileOutputSuccessAll(t *testing.T) {
 }
 
 func TestDestinationFileOutputFailedToWrite(t *testing.T) {
-	tempDirPath, err := ioutil.TempDir("", "test")
+	tempDirPath, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Errorf("failed to create tempdir: %s", err)
 	}
@@ -88,7 +88,7 @@ func TestDestinationFileOutputFailedToWrite(t *testing.T) {
 }
 
 func makeTempfileName(t *testing.T) string {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.26.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.9
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.49.4
+	github.com/google/go-cmp v0.6.0
 )
 
 require (
@@ -20,6 +21,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.5 // indirect
 	github.com/aws/smithy-go v1.20.1 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )


### PR DESCRIPTION
io/ioutil is deprecated in go 1.16 or later
https://go.dev/doc/go1.16#ioutil