### PR TITLE
go import path for v2

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -3,7 +3,7 @@ name: tagpr
 on:
   push:
     branches:
-      - main
+      - v2
 
 jobs:
   tagpr:

--- a/.tagpr
+++ b/.tagpr
@@ -38,5 +38,5 @@
 #
 [tagpr]
 	vPrefix = true
-	releaseBranch = main
+	releaseBranch = v2
 	versionFile = VERSION

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/handlename/ssmwrap"
-	"github.com/handlename/ssmwrap/internal/app"
-	"github.com/handlename/ssmwrap/internal/cli"
+	"github.com/handlename/ssmwrap/v2"
+	"github.com/handlename/ssmwrap/v2/internal/app"
+	"github.com/handlename/ssmwrap/v2/internal/cli"
 )
 
 type ExitStatus int

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/handlename/ssmwrap/internal/app"
-	"github.com/handlename/ssmwrap/internal/cli"
+	"github.com/handlename/ssmwrap/v2/internal/app"
+	"github.com/handlename/ssmwrap/v2/internal/cli"
 	"github.com/samber/lo"
 )
 

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/handlename/ssmwrap/cli"
+	"github.com/handlename/ssmwrap/v2/cli"
 )
 
 var version string

--- a/examples/lib/main.go
+++ b/examples/lib/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/handlename/ssmwrap"
+	"github.com/handlename/ssmwrap/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/handlename/ssmwrap
+module github.com/handlename/ssmwrap/v2
 
 go 1.22
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.9
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.49.4
 	github.com/google/go-cmp v0.6.0
+	github.com/samber/lo v1.39.0
 )
 
 require (
@@ -22,6 +23,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.5 // indirect
 	github.com/aws/smithy-go v1.20.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/samber/lo v1.39.0 // indirect
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8 // indirect
 )

--- a/internal/cli/env_flags_test.go
+++ b/internal/cli/env_flags_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/handlename/ssmwrap/internal/app"
+	"github.com/handlename/ssmwrap/v2/internal/app"
 )
 
 func TestEnvFlagsSuccess(t *testing.T) {

--- a/internal/cli/file_flags_test.go
+++ b/internal/cli/file_flags_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/handlename/ssmwrap/internal/app"
+	"github.com/handlename/ssmwrap/v2/internal/app"
 )
 
 func TestFileFlagsSuccess(t *testing.T) {

--- a/internal/cli/rule_flags.go
+++ b/internal/cli/rule_flags.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/handlename/ssmwrap/internal/app"
+	"github.com/handlename/ssmwrap/v2/internal/app"
 	"github.com/samber/lo"
 )
 

--- a/internal/cli/rule_flags_test.go
+++ b/internal/cli/rule_flags_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/handlename/ssmwrap/internal/app"
+	"github.com/handlename/ssmwrap/v2/internal/app"
 )
 
 func TestRuleFlagsSetSuccess(t *testing.T) {

--- a/lib.go
+++ b/lib.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/handlename/ssmwrap/internal/app"
+	"github.com/handlename/ssmwrap/v2/internal/app"
 )
 
 type ExportOptions struct {


### PR DESCRIPTION
On v2, library interfaces has changed.
To keep compatibility for v1, changed go import path for v2.
