### PR TITLE
Skip overlapped rules

### DIFF
--- a/internal/app/parameter_rule.go
+++ b/internal/app/parameter_rule.go
@@ -73,3 +73,38 @@ func (r ParameterRule) String() string {
 
 	return s
 }
+
+func (r1 ParameterRule) Equals(r2 ParameterRule) bool {
+	return r1.Path == r2.Path && r1.Level == r2.Level
+}
+
+func (r1 ParameterRule) IsCovers(r2 ParameterRule) bool {
+	if r1.Equals(r2) {
+		return true
+	}
+
+	switch r1.Level {
+	case ParameterLevelStrict:
+		return false
+	case ParameterLevelUnder:
+		if r2.Level == ParameterLevelAll {
+			return false
+		}
+
+		if strings.HasPrefix(r2.Path, r1.Path) {
+			// Is r2 just unedr r1?
+			s := strings.Replace(r2.Path, r1.Path, "", 1)
+			if strings.Contains(s, "/") {
+				return false
+			}
+
+			return true
+		}
+	case ParameterLevelAll:
+		if strings.HasPrefix(r2.Path, r1.Path) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/app/parameter_rule_test.go
+++ b/internal/app/parameter_rule_test.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParameterRuleIsCovers(t *testing.T) {
+	tests := []struct {
+		r1   ParameterRule
+		r2   ParameterRule
+		want bool
+	}{
+		{
+			r1: ParameterRule{
+				Path:  "/foo/v1",
+				Level: ParameterLevelStrict,
+			},
+			r2: ParameterRule{
+				Path:  "/foo/v1",
+				Level: ParameterLevelStrict,
+			},
+			want: true,
+		},
+		{
+			r1: ParameterRule{
+				Path:  "/foo/",
+				Level: ParameterLevelUnder,
+			},
+			r2: ParameterRule{
+				Path:  "/foo/v1",
+				Level: ParameterLevelStrict,
+			},
+			want: true,
+		},
+		{
+			r1: ParameterRule{
+				Path:  "/foo/",
+				Level: ParameterLevelUnder,
+			},
+			r2: ParameterRule{
+				Path:  "/foo/v1/value",
+				Level: ParameterLevelStrict,
+			},
+			want: false,
+		},
+		{
+			r1: ParameterRule{
+				Path:  "/foo/",
+				Level: ParameterLevelAll,
+			},
+			r2: ParameterRule{
+				Path:  "/foo/v1/value",
+				Level: ParameterLevelStrict,
+			},
+			want: true,
+		},
+		{
+			r1: ParameterRule{
+				Path:  "/foo/",
+				Level: ParameterLevelAll,
+			},
+			r2: ParameterRule{
+				Path:  "/foo/",
+				Level: ParameterLevelUnder,
+			},
+			want: true,
+		},
+		{
+			r1: ParameterRule{
+				Path:  "/foo/",
+				Level: ParameterLevelUnder,
+			},
+			r2: ParameterRule{
+				Path:  "/foo/",
+				Level: ParameterLevelAll,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s covers %s -> %t", tt.r1, tt.r2, tt.want), func(t *testing.T) {
+			if tt.r1.IsCovers(tt.r2) != tt.want {
+				t.Errorf("unexpected result")
+			}
+		})
+	}
+}


### PR DESCRIPTION
When run like flags below:

```console
$ ssmwrap \
    -env 'path=/foo/value1' \
    -env 'path=/foo/*' \
    -- do_something
```

ssmwrap requests to SSM Parameter Store 2 times, but first one is covered by second rule.
( `/foo/*` contains `/foo/value` )

This PR skips overlapped rules to:

- Reduce API request cost
- Surpress warnings produced by [here](https://github.com/handlename/ssmwrap/blob/6339d7f7393104cb6135cd3a0d2feb663f9f591f/internal/app/parameter_store.go#L104)
