### PR TITLE
Release for v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.1.0](https://github.com/handlename/ssmwrap/compare/v2.0.1...v2.1.0) - 2024-05-20
+- Skip overlapped rules by @handlename in https://github.com/handlename/ssmwrap/pull/79
+- Replace slog handler by @handlename in https://github.com/handlename/ssmwrap/pull/81
+- Release by goreleaser by @handlename in https://github.com/handlename/ssmwrap/pull/82
+- Update README: how to install v2 by @handlename in https://github.com/handlename/ssmwrap/pull/83
+
 ## [v2.0.1](https://github.com/handlename/ssmwrap/compare/v2.0.0...v2.0.1) - 2024-05-10
 - go import path for v2 by @handlename in https://github.com/handlename/ssmwrap/pull/76
 - Update license URL to not depend on branch name by @handlename in https://github.com/handlename/ssmwrap/pull/78

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.0.1"
+const version = "2.1.0"
 
 const FlagEnvPrefix = "SSMWRAP_"
 


### PR DESCRIPTION
This pull request is for the next release as v2.1.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.1.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at v2 -->

## What's Changed
* Skip overlapped rules by @handlename in https://github.com/handlename/ssmwrap/pull/79
* Replace slog handler by @handlename in https://github.com/handlename/ssmwrap/pull/81
* Release by goreleaser by @handlename in https://github.com/handlename/ssmwrap/pull/82
* Update README: how to install v2 by @handlename in https://github.com/handlename/ssmwrap/pull/83


**Full Changelog**: https://github.com/handlename/ssmwrap/compare/v2.0.1...v2.1.0