### PR TITLE
Release for v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.1.1](https://github.com/handlename/ssmwrap/compare/v2.1.0...v2.1.1) - 2024-07-01
+## [v2.2.0](https://github.com/handlename/ssmwrap/compare/v2.1.0...v2.2.0) - 2024-07-01
 - Fix install command in README by @handlename in https://github.com/handlename/ssmwrap/pull/87
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.49.4 to 1.52.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/89
 - chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.26.1 to 1.30.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v2.1.1](https://github.com/handlename/ssmwrap/compare/v2.1.0...v2.1.1) - 2024-07-01
+- Fix install command in README by @handlename in https://github.com/handlename/ssmwrap/pull/87
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.49.4 to 1.52.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/89
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.26.1 to 1.30.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/90
+- chore(deps): bump github.com/samber/lo from 1.39.0 to 1.44.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/91
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.27.12 to 1.27.23 by @dependabot in https://github.com/handlename/ssmwrap/pull/92
+
 ## [v2.1.0](https://github.com/handlename/ssmwrap/compare/v2.0.1...v2.1.0) - 2024-05-20
 - Skip overlapped rules by @handlename in https://github.com/handlename/ssmwrap/pull/79
 - Replace slog handler by @handlename in https://github.com/handlename/ssmwrap/pull/81

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.1.0"
+const version = "2.1.1"
 
 const FlagEnvPrefix = "SSMWRAP_"
 

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.1.1"
+const version = "2.2.0"
 
 const FlagEnvPrefix = "SSMWRAP_"
 


### PR DESCRIPTION
This pull request is for the next release as v2.2.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.2.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at v2 -->

## What's Changed
* Fix install command in README by @handlename in https://github.com/handlename/ssmwrap/pull/87
* chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.49.4 to 1.52.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/89
* chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.26.1 to 1.30.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/90
* chore(deps): bump github.com/samber/lo from 1.39.0 to 1.44.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/91
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.27.12 to 1.27.23 by @dependabot in https://github.com/handlename/ssmwrap/pull/92


**Full Changelog**: https://github.com/handlename/ssmwrap/compare/v2.1.0...v2.2.0