### PR TITLE
Bump up go1.24 due to CVE-2024-24791

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '^1.22.1'
+          - '^1.24.1'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/handlename/ssmwrap/v2
 
-go 1.22
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.1


### PR DESCRIPTION
Due to AWS Inspector scans showing CVE-2024-24791 as a high vulnerability, the Go version has been raised to 1.24.

Sorry for the inconvenience, release, please.  😢 