### PR TITLE
Release for v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v2.2.1](https://github.com/handlename/ssmwrap/compare/v2.2.0...v2.2.1) - 2025-03-29
+- Bump up go1.24 due to CVE-2024-24791 by @comi91262 in https://github.com/handlename/ssmwrap/pull/105
+- chore(deps): bump github.com/lmittmann/tint from 1.0.4 to 1.0.5 by @dependabot in https://github.com/handlename/ssmwrap/pull/97
+- chore(deps): bump github.com/samber/lo from 1.44.0 to 1.47.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/100
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.52.1 to 1.54.3 by @dependabot in https://github.com/handlename/ssmwrap/pull/102
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.30.1 to 1.31.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/103
+- Fix build error: non-consistant format string in call to fmt.Errorf by @handlename in https://github.com/handlename/ssmwrap/pull/107
+- Update and pin actions by @handlename in https://github.com/handlename/ssmwrap/pull/108
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.27.23 to 1.27.39 by @dependabot in https://github.com/handlename/ssmwrap/pull/104
+
 ## [v2.2.0](https://github.com/handlename/ssmwrap/compare/v2.1.0...v2.2.0) - 2024-07-01
 - Fix install command in README by @handlename in https://github.com/handlename/ssmwrap/pull/87
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.49.4 to 1.52.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/89

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.2.0"
+const version = "2.2.1"
 
 const FlagEnvPrefix = "SSMWRAP_"
 


### PR DESCRIPTION
This pull request is for the next release as v2.2.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.2.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.2.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at v2 -->

## What's Changed
* Bump up go1.24 due to CVE-2024-24791 by @comi91262 in https://github.com/handlename/ssmwrap/pull/105
* chore(deps): bump github.com/lmittmann/tint from 1.0.4 to 1.0.5 by @dependabot in https://github.com/handlename/ssmwrap/pull/97
* chore(deps): bump github.com/samber/lo from 1.44.0 to 1.47.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/100
* chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.52.1 to 1.54.3 by @dependabot in https://github.com/handlename/ssmwrap/pull/102
* chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.30.1 to 1.31.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/103
* Fix build error: non-consistant format string in call to fmt.Errorf by @handlename in https://github.com/handlename/ssmwrap/pull/107
* Update and pin actions by @handlename in https://github.com/handlename/ssmwrap/pull/108
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.27.23 to 1.27.39 by @dependabot in https://github.com/handlename/ssmwrap/pull/104

## New Contributors
* @comi91262 made their first contribution in https://github.com/handlename/ssmwrap/pull/105

**Full Changelog**: https://github.com/handlename/ssmwrap/compare/v2.2.0...v2.2.1