### PR TITLE
Release for v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v2.2.2](https://github.com/handlename/ssmwrap/compare/v2.2.1...v2.2.2) - 2025-03-29
+- Fix: docker image build by @handlename in https://github.com/handlename/ssmwrap/pull/109
+
 ## [v2.2.1](https://github.com/handlename/ssmwrap/compare/v2.2.0...v2.2.1) - 2025-03-29
 - Bump up go1.24 due to CVE-2024-24791 by @comi91262 in https://github.com/handlename/ssmwrap/pull/105
 - chore(deps): bump github.com/lmittmann/tint from 1.0.4 to 1.0.5 by @dependabot in https://github.com/handlename/ssmwrap/pull/97

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.2.1"
+const version = "2.2.2"
 
 const FlagEnvPrefix = "SSMWRAP_"
 


### PR DESCRIPTION
This pull request is for the next release as v2.2.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.2.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.2.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at v2 -->

## What's Changed
* Fix: docker image build by @handlename in https://github.com/handlename/ssmwrap/pull/109


**Full Changelog**: https://github.com/handlename/ssmwrap/compare/v2.2.1...v2.2.2