### PR TITLE
Release for v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v2.3.0](https://github.com/handlename/ssmwrap/compare/v2.2.2...v2.3.0) - 2025-04-30
+- use the latest patch version of Go by @fujiwara in https://github.com/handlename/ssmwrap/pull/115
+- chore(deps): bump github.com/google/go-cmp from 0.6.0 to 0.7.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/111
+- chore(deps): bump github.com/samber/lo from 1.47.0 to 1.49.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/112
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.54.3 to 1.58.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/113
+- chore(deps): bump github.com/lmittmann/tint from 1.0.5 to 1.0.7 by @dependabot in https://github.com/handlename/ssmwrap/pull/114
+
 ## [v2.2.2](https://github.com/handlename/ssmwrap/compare/v2.2.1...v2.2.2) - 2025-03-29
 - Fix: docker image build by @handlename in https://github.com/handlename/ssmwrap/pull/109
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.3.0](https://github.com/handlename/ssmwrap/compare/v2.2.2...v2.3.0) - 2025-04-30
+## [v2.2.3](https://github.com/handlename/ssmwrap/compare/v2.2.2...v2.2.3) - 2025-04-30
 - use the latest patch version of Go by @fujiwara in https://github.com/handlename/ssmwrap/pull/115
 - chore(deps): bump github.com/google/go-cmp from 0.6.0 to 0.7.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/111
 - chore(deps): bump github.com/samber/lo from 1.47.0 to 1.49.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/112

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.3.0"
+const version = "2.2.3"
 
 const FlagEnvPrefix = "SSMWRAP_"
 

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.2.2"
+const version = "2.3.0"
 
 const FlagEnvPrefix = "SSMWRAP_"
 


### PR DESCRIPTION
This pull request is for the next release as v2.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.2.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at v2 -->

## What's Changed
* use the latest patch version of Go by @fujiwara in https://github.com/handlename/ssmwrap/pull/115
* chore(deps): bump github.com/google/go-cmp from 0.6.0 to 0.7.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/111
* chore(deps): bump github.com/samber/lo from 1.47.0 to 1.49.1 by @dependabot in https://github.com/handlename/ssmwrap/pull/112
* chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ssm from 1.54.3 to 1.58.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/113
* chore(deps): bump github.com/lmittmann/tint from 1.0.5 to 1.0.7 by @dependabot in https://github.com/handlename/ssmwrap/pull/114


**Full Changelog**: https://github.com/handlename/ssmwrap/compare/v2.2.2...v2.3.0