### PR TITLE
Release for v2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v2.3.0](https://github.com/handlename/ssmwrap/compare/v2.2.3...v2.3.0) - 2025-09-07
+- Added integration test by @handlename in https://github.com/handlename/ssmwrap/pull/118
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.12 to 1.29.14 by @dependabot[bot] in https://github.com/handlename/ssmwrap/pull/117
+- goreleaser conf v2 by @handlename in https://github.com/handlename/ssmwrap/pull/120
+- Enable draft release by @handlename in https://github.com/handlename/ssmwrap/pull/134
+- chore: Configure Renovate by @renovate[bot] in https://github.com/handlename/ssmwrap/pull/135
+- Stop dependabot by @handlename in https://github.com/handlename/ssmwrap/pull/139
+- chore(deps): bump github.com/samber/lo from 1.50.0 to 1.51.0 by @dependabot[bot] in https://github.com/handlename/ssmwrap/pull/122
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.14 to 1.31.6 by @dependabot[bot] in https://github.com/handlename/ssmwrap/pull/133
+- chore(deps): update actions/checkout action to v4.3.0 by @renovate[bot] in https://github.com/handlename/ssmwrap/pull/136
+- chore(deps): update actions/setup-go action to v5.5.0 by @renovate[bot] in https://github.com/handlename/ssmwrap/pull/137
+
 ## [v2.2.3](https://github.com/handlename/ssmwrap/compare/v2.2.2...v2.2.3) - 2025-04-30
 - use the latest patch version of Go by @fujiwara in https://github.com/handlename/ssmwrap/pull/115
 - chore(deps): bump github.com/google/go-cmp from 0.6.0 to 0.7.0 by @dependabot in https://github.com/handlename/ssmwrap/pull/111

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.3.0](https://github.com/handlename/ssmwrap/compare/v2.2.3...v2.3.0) - 2025-09-07
+## [v2.2.4](https://github.com/handlename/ssmwrap/compare/v2.2.3...v2.2.4) - 2025-09-07
 - Added integration test by @handlename in https://github.com/handlename/ssmwrap/pull/118
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.12 to 1.29.14 by @dependabot[bot] in https://github.com/handlename/ssmwrap/pull/117
 - goreleaser conf v2 by @handlename in https://github.com/handlename/ssmwrap/pull/120

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.2.3"
+const version = "2.3.0"
 
 const FlagEnvPrefix = "SSMWRAP_"
 

--- a/cmd/ssmwrap/main.go
+++ b/cmd/ssmwrap/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/handlename/ssmwrap/v2/cli"
 )
 
-const version = "2.3.0"
+const version = "2.2.4"
 
 const FlagEnvPrefix = "SSMWRAP_"
 


### PR DESCRIPTION
This pull request is for the next release as v2.2.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.2.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.2.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at v2 -->

## What's Changed
* Added integration test by @handlename in https://github.com/handlename/ssmwrap/pull/118
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.12 to 1.29.14 by @dependabot[bot] in https://github.com/handlename/ssmwrap/pull/117
* goreleaser conf v2 by @handlename in https://github.com/handlename/ssmwrap/pull/120
* Enable draft release by @handlename in https://github.com/handlename/ssmwrap/pull/134
* chore: Configure Renovate by @renovate[bot] in https://github.com/handlename/ssmwrap/pull/135
* Stop dependabot by @handlename in https://github.com/handlename/ssmwrap/pull/139
* chore(deps): bump github.com/samber/lo from 1.50.0 to 1.51.0 by @dependabot[bot] in https://github.com/handlename/ssmwrap/pull/122
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.14 to 1.31.6 by @dependabot[bot] in https://github.com/handlename/ssmwrap/pull/133
* chore(deps): update actions/checkout action to v4.3.0 by @renovate[bot] in https://github.com/handlename/ssmwrap/pull/136
* chore(deps): update actions/setup-go action to v5.5.0 by @renovate[bot] in https://github.com/handlename/ssmwrap/pull/137

## New Contributors
* @renovate[bot] made their first contribution in https://github.com/handlename/ssmwrap/pull/135

**Full Changelog**: https://github.com/handlename/ssmwrap/compare/v2.2.3...v2.2.4