### PR TITLE
Enable draft release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,3 +4,5 @@ builds:
   - env:
       - CGO_ENABLED=0
     main: ./cmd/ssmwrap
+release:
+  use_existing_draft: true

--- a/.tagpr
+++ b/.tagpr
@@ -38,5 +38,6 @@
 #
 [tagpr]
 	vPrefix = true
+	release = draft
 	releaseBranch = v2
 	versionFile = cmd/ssmwrap/main.go


### PR DESCRIPTION
- [Releases now support immutability in public preview - GitHub Changelog](https://github.blog/changelog/2025-08-26-releases-now-support-immutability-in-public-preview/)
- [GitHub の Immutable Releases を有効にしてセキュリティインシデントを防ごう](https://zenn.dev/shunsuke_suzuki/articles/github-immutable-release)
- [immutable releasesを有効にする際のtagprとgoreleaserの設定 | おそらくはそれさえも平凡な日々](https://songmu.jp/riji/entry/2025-09-05-coordinate-tagpr-and-goreleaser-with-immutable-releases.html)